### PR TITLE
3.1.3 as パターン

### DIFF
--- a/as_pattern.hs
+++ b/as_pattern.hs
@@ -1,0 +1,3 @@
+firstLetter :: String -> String
+firstLetter "" = "Empty string, whoops!"
+firstLetter all@(x:xs) = "The first letter of " ++ all ++ " is " ++ [x]


### PR DESCRIPTION
# asパターン

値をパターンに分割して元のパターン自体も使う場合に使う

``` haskell
all@(x:xs) = all ++ x
```

 `all` に元のパターンが束縛されて `all` で元のパターンを使用できる

x と xs はちゃんと分割されている。
