### PR TITLE
3.4 let it be

### DIFF
--- a/cylinder.hs
+++ b/cylinder.hs
@@ -1,0 +1,5 @@
+cylender :: Double -> Double -> Double
+cylender r h =
+  let sideArea = 2 * pi * r * h
+      topArea = pi * r ^ 2
+  in  sideArea + 2 * topArea


### PR DESCRIPTION
let 変数の束縛

let式は `let "bindings" in "expression"` という形になる

let で定義した変数は let 式全体から見える。
#### where
- 関数終了まで値を保持
- ガードを含む関数全体から見える
#### let
- どこでも定義可能
- ガード毎に共有はされない

let式はリスト内包表記でも使える。
- let のスコープは局所的で、ガードをまたいでは使えない
- 関数の前ではなく後ろで部品を定義したほうが好ましい（where を使う）
  - 関数の本体が名前と型宣言に近くなるのでコードが読みやすくなる
